### PR TITLE
Package passport-google-oauth20 v2.0.0

### DIFF
--- a/trainingportal/package.json
+++ b/trainingportal/package.json
@@ -34,7 +34,7 @@
     "node-truncate": "^0.1.0",
     "open-iconic": "^1.1.1",
     "passport": "^0.3.2",
-    "passport-google-oauth20": "^1.0.0",
+    "passport-google-oauth20": "^2.0.0",
     "passport-ldapauth": "^2.1.4",
     "passport-local": "^1.0.0",
     "passport-saml": "^0.33.0",


### PR DESCRIPTION
Google oauth20 v1 is using a legacy google plus Persons API which does not work anymore. 
https://developers.google.com/people/legacy

This version change is transparent and enables the Google oauth2 authentication flow.  