### PR TITLE
Fix invalid variable name

### DIFF
--- a/trainingportal/db.js
+++ b/trainingportal/db.js
@@ -197,7 +197,7 @@ exports.init = async () => {
       util.log("Database tables created");
     } catch (error) {
       util.log("Database setup failed");
-      console.log(err);
+      console.log(error);
     }
     
   }


### PR DESCRIPTION
If database error occurs, application was trying to log content of `err` variable instead of content of `error` variable