### PR TITLE
Fixed config.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ Check out the [wiki](https://github.com/OWASP/SecureCodingDojo/wiki/Running-Inse
 
 More info on the [wiki](https://github.com/OWASP/SecureCodingDojo/wiki/Running-the-training-portal).
 
+Updating the contents of [wiki](https://github.com/OWASP/SecureCodingDojo/wiki/Running-the-training-portal). As the previous **securityCodeReviewMaster** url is no longer working, added a new working url.\
+Here's the updated sample config.json configuration. Save this file to the $DATA_DIR
+
+```
+{
+    "dojoUrl" : "YOUR_DOJO_PUBLIC_URL",
+    "moduleUrls" : {
+        "blackBelt":"YOUR_INSECURE_INC_PUBLIC_URL",
+        "securityCodeReviewMaster":"https://owasp.org/SecureCodingDojo/codereview101/?fromPortal"
+    },
+
+    "localUsersPath" : "localUsers.json",
+}
+```
+
 # Slack Setup Instructions
 You will need to create a Slack app for authentication.
 - Go to https://api.slack.com/


### PR DESCRIPTION
As the [wiki](https://github.com/OWASP/SecureCodingDojo/wiki/Running-the-training-portal), presented with running training portal with docker. However, when it's hosted on AWS and mounted with $DATA_DIR, to expose the the Training Portal and Insecureinc, when a config.json file is added to it, the wiki presented the **securityCodeReviewMaster** url which is no longer working, hence I updated the  **securityCodeReviewMaster** with the correct url below - 
```
{
    "dojoUrl" : "YOUR_DOJO_PUBLIC_URL",
    "moduleUrls" : {
        "blackBelt":"YOUR_INSECURE_INC_PUBLIC_URL",
        "securityCodeReviewMaster":"https://owasp.org/SecureCodingDojo/codereview101/?fromPortal"
    },

    "localUsersPath" : "localUsers.json",
}
```