### PR TITLE
red team Dockerfile update for drupal:8.5.0 resolved 404 error while running apt-get update

### DIFF
--- a/redblueapp/Dockerfile
+++ b/redblueapp/Dockerfile
@@ -1,5 +1,14 @@
 FROM drupal:8.5.0
 
+# Use sed to remove the specified lines from sources.list as these deb.debian.org returning 404 error
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian stretch main/d' /etc/apt/sources.list
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian stretch-updates main/d' /etc/apt/sources.list
+RUN sed -i '/deb http:\/\/security.debian.org stretch\/updates main/d' /etc/apt/sources.list
+
+# Use echo to append the repository lines to the sources.list file to fetch the packages from archive
+RUN echo "deb http://archive.debian.org/debian/ stretch main" >> /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian-security/ stretch/updates main" >> /etc/apt/sources.list
+
 RUN apt-get update
 RUN apt-get -y install supervisor
 RUN apt-get -y install iputils-ping

--- a/redblueapp/buildAndRun.sh
+++ b/redblueapp/buildAndRun.sh
@@ -1,2 +1,4 @@
 docker build -t securecodingdojo/redblueapp .
+CHALLENGE_MASTER_SALT=$(openssl rand -hex 16)
+echo $CHALLENGE_MASTER_SALT
 docker run -p 8888:8888 -p 8080:80 -e MASTER_SALT="$CHALLENGE_MASTER_SALT" securecodingdojo/redblueapp

--- a/redblueapp/buildAndRun.sh
+++ b/redblueapp/buildAndRun.sh
@@ -1,4 +1,2 @@
 docker build -t securecodingdojo/redblueapp .
-CHALLENGE_MASTER_SALT=$(openssl rand -hex 16)
-echo $CHALLENGE_MASTER_SALT
 docker run -p 8888:8888 -p 8080:80 -e MASTER_SALT="$CHALLENGE_MASTER_SALT" securecodingdojo/redblueapp


### PR DESCRIPTION
removed deb.debian.org from the source.list was getting 404 error and amended archive.debian.org.
Added command to generate CHALLENGE_MASTER_SALT via openssl.